### PR TITLE
Fix model download corruption

### DIFF
--- a/Aura/Services/MLXModelManager.swift
+++ b/Aura/Services/MLXModelManager.swift
@@ -353,11 +353,11 @@ class MLXModelManager: ObservableObject {
 
                 var written: Int64 = 0
                 var buffer = Data()
-                buffer.reserveCapacity(1024 * 1024)
+                buffer.reserveCapacity(Self.bufferSize)
 
                 for try await byte in bytes {
                     buffer.append(byte)
-                    if buffer.count >= 1024 * 1024 {
+                    if buffer.count >= Self.bufferSize {
                         fileHandle.write(buffer)
                         written += Int64(buffer.count)
                         progress(Int64(buffer.count))

--- a/Aura/Services/MLXModelManager.swift
+++ b/Aura/Services/MLXModelManager.swift
@@ -371,7 +371,6 @@ class MLXModelManager: ObservableObject {
                     written += Int64(buffer.count)
                     progress(Int64(buffer.count))
                 }
-                try fileHandle.close()
 
                 if let contentLengthStr = httpResponse.value(forHTTPHeaderField: "Content-Length"),
                    let contentLength = Int64(contentLengthStr) {

--- a/Aura/Services/MLXModelManager.swift
+++ b/Aura/Services/MLXModelManager.swift
@@ -373,8 +373,8 @@ class MLXModelManager: ObservableObject {
 
                 if let contentLengthStr = httpResponse.value(forHTTPHeaderField: "Content-Length"),
                    let contentLength = Int64(contentLengthStr) {
-                    guard written == contentLength else {
-                        print("⚠️ Content length mismatch: expected \(contentLength), got \(written)")
+                    guard existingSize + written == contentLength else {
+                        print("⚠️ Content length mismatch: expected \(contentLength), got \(existingSize + written)")
                         throw ModelError.downloadIncomplete
                     }
                 }

--- a/Aura/Services/MLXModelManager.swift
+++ b/Aura/Services/MLXModelManager.swift
@@ -234,10 +234,11 @@ class MLXModelManager: ObservableObject {
                    let lengthStr = httpResponse.value(forHTTPHeaderField: "Content-Length"),
                    let length = Int64(lengthStr) {
                     totalExpectedBytes += length
+                } else {
+                    totalExpectedBytes += estimatedBytesPerFile
                 }
             } catch {
-                totalExpectedBytes = Int64(self.estimatedSizeGB * 1024 * 1024 * 1024)
-                break
+                totalExpectedBytes += estimatedBytesPerFile
             }
         }
 

--- a/Aura/Services/MLXModelManager.swift
+++ b/Aura/Services/MLXModelManager.swift
@@ -349,7 +349,9 @@ class MLXModelManager: ObservableObject {
                 defer {
                     try? fileHandle.close()
                 }
-                if existingSize > 0 { fileHandle.seekToEndOfFile() }
+                if existingSize > 0 {
+                    fileHandle.seekToEndOfFile()
+                }
 
                 var written: Int64 = 0
                 var buffer = Data()

--- a/Aura/Services/MLXModelManager.swift
+++ b/Aura/Services/MLXModelManager.swift
@@ -346,6 +346,9 @@ class MLXModelManager: ObservableObject {
                     FileManager.default.createFile(atPath: tempURL.path, contents: nil)
                 }
                 let fileHandle = try FileHandle(forWritingTo: tempURL)
+                defer {
+                    try? fileHandle.close()
+                }
                 if existingSize > 0 { fileHandle.seekToEndOfFile() }
 
                 var written: Int64 = 0


### PR DESCRIPTION
## Summary
- Calculate overall model size via HEAD requests and track progress by downloaded bytes
- Stream download shards in chunks and invoke a progress callback to update UI in real time

## Testing
- `xcodebuild -project Aura.xcodeproj -scheme Aura -configuration Debug build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893a6294d9c832e9960133d0431e675